### PR TITLE
Update to work on non-bastion-protected hosts and non-multisite-network WordPress installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md).
       - `wp-config.php` is already setup
       - user has appopriate permissions (ex. member of `www-data`)
       - [WP-CLI][wp-cli] is already installed
-   2. You may need to configure your users `.ssh/config`. For example,
+   2. You may need to configure your `.ssh/config`. For example,
       `chapters_stage` requires the following entry:
         ```
         Host 10.22.10.14
@@ -50,7 +50,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 ## Use
 
 1. `SOURCE_HOST`: *(optional)*
-   - run [`backup_wordpress.sh`][backup] on the
+   - run [`backup_wordpress.sh`][backup]
 2. Local/laptop:
    1. Clone this repository
    2. Prepare configuration file
@@ -58,7 +58,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md).
          [`config_examples/`](config_examples/)
       2. Replace `FILEPATH` and `USERNAME` with your information
       3. Ensure `SOURCE_DB_FILE` and `SOURCE_UPLOADS_FILE` are valid files on
-         the `SOURCE_HOST`.
+         the `SOURCE_HOST` (ex. by completing step 1, above)
    3. Execute script with config file as only argument. For example:
         ```shell
         ./wp-pull.sh chapters__stage

--- a/bin/wp-pull-remote.sh
+++ b/bin/wp-pull-remote.sh
@@ -41,6 +41,13 @@ create_temp_dir() {
 db_update_domain_wp_blogs() {
     headerone 'DEST_HOST: Updating domain in wp_blogs table'
     pushd ${DEST_WP_DIR} >/dev/null
+    if ! wp db query "SHOW CREATE TABLE wp_blogs" &>/dev/null
+    then
+        echo 'Table wp_blogs does not exist. Skipping.'
+        echo
+        popd >/dev/null
+        return
+    fi
     wp db query "
         SELECT domain AS 'domain__contains__DEST_DOMAIN'
         FROM wp_blogs
@@ -63,6 +70,13 @@ db_update_domain_wp_blogs() {
 db_update_domain_wp_domain_mapping() {
     headerone 'DEST_HOST: Updating domain in wp_domain_mapping table'
     pushd ${DEST_WP_DIR} >/dev/null
+    if ! wp db query "SHOW CREATE TABLE wp_domain_mapping" &>/dev/null
+    then
+        echo 'Table wp_domain_mapping does not exist. Skipping.'
+        echo
+        popd >/dev/null
+        return
+    fi
     wp db query "
         SELECT domain AS 'domain__contains__SOURCE_DOMAIN'
         FROM wp_domain_mapping

--- a/bin/wp-pull-remote.sh
+++ b/bin/wp-pull-remote.sh
@@ -201,8 +201,7 @@ import_database() {
 
 pull_data() {
     headerone 'DEST_HOST: Pulling data from SOURCE_HOST_REMOTE'
-    scp -oProxyJump=${BASTION_HOST_REMOTE} \
-        ${SOURCE_HOST_REMOTE}:${SOURCE_DB_FILE} \
+    scp ${SOURCE_HOST_REMOTE}:${SOURCE_DB_FILE} \
         ${SOURCE_HOST_REMOTE}:${SOURCE_UPLOADS_FILE} \
         ${TEMP_DIR}/
     PULLED_DB_FILE="${TEMP_DIR}/${SOURCE_DB_FILE##*/}"

--- a/config_examples/chapters__stage
+++ b/config_examples/chapters__stage
@@ -4,7 +4,6 @@
 # DEST_UPLOADS_DIR: /var/www/chapters/wp-content/uploads
 # DEST_TEMP_DIR: /var/www/chapters
 # DEST_WP_DIR: /var/www/chapters/wp
-# BASTION_HOST_REMOTE: 10.22.10.10
 # SOURCE_HOST_REMOTE: 10.22.10.14
 # SOURCE_DOMAIN: creativecommons.net
 # SOURCE_DB_FILE: /var/www/chapters/backup/now/db.sql.gz

--- a/wp-pull.sh
+++ b/wp-pull.sh
@@ -23,8 +23,6 @@ Configuration File Variables:
                             destination host (will be destroyed and replaced)
     DEST_WP_DIR             Absolute path of WordPress directory (where to run
                             WP-CLI from)
-    BASTION_HOST_REMOTE     Bastion or Jump Host used to connect to
-                            SOURCE_HOST_REMOTE
     SOURCE_HOST_REMOTE      Host to pull WordPress data from
     SOURCE_DOMAIN           Domain/Site URL of the source WordPress
     SOURCE_DB_FILE          Absolute path of the database file (.sql.gz)
@@ -73,8 +71,6 @@ display_summary_and_confirm(){
     echo "${DKG}DEST_UPLOADS_DIR:${RST}    ${DEST_UPLOADS_DIR}"
     echo "${DKG}DEST_WP_DIR:${RST}         ${DEST_WP_DIR}"
     echo
-    echo "${DKG}BASTION_HOST_REMOTE:${RST} ${BASTION_HOST_REMOTE}"
-    echo
     echo "${DKG}SOURCE_HOST_REMOTE:${RST}  ${SOURCE_HOST_REMOTE}"
     echo "${DKG}SOURCE_DOMAIN:${RST}       ${SOURCE_DOMAIN}"
     echo "${DKG}SOURCE_DB_FILE:${RST}      ${SOURCE_DB_FILE}"
@@ -115,7 +111,6 @@ execute_remote_script() {
         export DEST_UPLOADS_DIR=\"${DEST_UPLOADS_DIR}\"
         export DEST_TEMP_DIR=\"${DEST_TEMP_DIR}\"
         export DEST_WP_DIR=\"${DEST_WP_DIR}\"
-        export BASTION_HOST_REMOTE=\"${BASTION_HOST_REMOTE}\"
         export SOURCE_HOST_REMOTE=\"${SOURCE_HOST_REMOTE}\"
         export SOURCE_DOMAIN=\"${SOURCE_DOMAIN}\"
         export SOURCE_DB_FILE=\"${SOURCE_DB_FILE}\"
@@ -134,7 +129,6 @@ extract_variables_from_config() {
     DEST_TEMP_DIR="${DEST_TEMP_DIR%/}"
     DEST_WP_DIR="$(awk '/^# DEST_WP_DIR:/ {print $3}' "${_f}")"
     DEST_WP_DIR="${DEST_WP_DIR%/}"
-    BASTION_HOST_REMOTE="$(awk '/^# BASTION_HOST_REMOTE:/ {print $3}' "${_f}")"
     SOURCE_HOST_REMOTE="$(awk '/^# SOURCE_HOST_REMOTE:/ {print $3}' "${_f}")"
     SOURCE_DOMAIN="$(awk '/^# SOURCE_DOMAIN:/ {print $3}' "${_f}")"
     SOURCE_DB_FILE="$(awk '/^# SOURCE_DB_FILE:/ {print $3}' "${_f}")"


### PR DESCRIPTION
## Fixes
Fixes #2 

## Description
- Removed `BASTION_HOST_REMOTE` variable. Instead, `ProxyJump` should be configured in destination host's `~/.ssh/config`, if required
- Updated to only update `wp_blogs` and `wp_domain_mapping` tables if they exist (they only exist for WordPress Multisite Networks)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
